### PR TITLE
Возврат nil ошибки метода Send.

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -109,7 +109,11 @@ func (a *messages) NewKeyboardBuilder() *Keyboard {
 
 // Send sends a message to a chat. As a result for this method new message identifier returns.
 func (a *messages) Send(ctx context.Context, m *Message) (string, error) {
-	return a.sendMessage(ctx, m.vip, m.reset, m.chatID, m.userID, m.message)
+	id, err := a.sendMessage(ctx, m.vip, m.reset, m.chatID, m.userID, m.message)
+	if err != nil && err.Error() != "" {
+		return "", err
+	}
+	return id, nil
 }
 
 // SendMessageResult sends a message to a chat and returns the message result.
@@ -210,6 +214,6 @@ func (a *messages) checkUser(ctx context.Context, reset bool, message *schemes.N
 	if len(result.NumberExist) > 0 {
 		return true, result
 	}
-	
+
 	return false, result
 }


### PR DESCRIPTION
Очень спорное решение из-за спорного решения возврата ошибок в приватном методе sendMessage(). Там никогда не может вернутся nil ошибка.

Чтобы полноценно отрефакторить этот приватный метод, нужен ответ на вопрос https://github.com/max-messenger/max-bot-api-client-go/issues/30

Но как временное ad hoc решение, можно использовать этот ПР.