### PR TITLE
Исправил тип messageID с int64 на string для DeleteMessage and EditMessage

### DIFF
--- a/api.go
+++ b/api.go
@@ -14,8 +14,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/max-messenger/max-bot-api-client-go/configservice"
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/configservice"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 const (

--- a/api_test.go
+++ b/api_test.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/max-messenger/max-bot-api-client-go/configservice"
-	"github.com/max-messenger/max-bot-api-client-go/mocks"
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/configservice"
+	"github.com/kpechenenko/max-bot-api-client-go/mocks"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 	"github.com/stretchr/testify/require"
 )
 

--- a/bots.go
+++ b/bots.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 type bots struct {

--- a/chats.go
+++ b/chats.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 type chats struct {

--- a/client.go
+++ b/client.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 var (

--- a/debugs.go
+++ b/debugs.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 type debugs struct {

--- a/examples/example.go
+++ b/examples/example.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"syscall"
 
-	maxbot "github.com/max-messenger/max-bot-api-client-go"
-	"github.com/max-messenger/max-bot-api-client-go/configservice"
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	maxbot "github.com/kpechenenko/max-bot-api-client-go"
+	"github.com/kpechenenko/max-bot-api-client-go/configservice"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"

--- a/examples/example_longpolling.go
+++ b/examples/example_longpolling.go
@@ -14,9 +14,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	maxbot "github.com/max-messenger/max-bot-api-client-go"
+	maxbot "github.com/kpechenenko/max-bot-api-client-go"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 func main() {

--- a/examples/example_webhook.go
+++ b/examples/example_webhook.go
@@ -12,9 +12,9 @@ import (
 	"net/http"
 	"os"
 
-	maxbot "github.com/max-messenger/max-bot-api-client-go"
+	maxbot "github.com/kpechenenko/max-bot-api-client-go"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/max-messenger/max-bot-api-client-go
+module github.com/kpechenenko/max-bot-api-client-go
 
 go 1.23.4
 

--- a/keyboard.go
+++ b/keyboard.go
@@ -1,6 +1,6 @@
 package maxbot
 
-import "github.com/max-messenger/max-bot-api-client-go/schemes"
+import "github.com/kpechenenko/max-bot-api-client-go/schemes"
 
 // Keyboard implements builder for inline keyboard
 type Keyboard struct {

--- a/message.go
+++ b/message.go
@@ -1,6 +1,6 @@
 package maxbot
 
-import "github.com/max-messenger/max-bot-api-client-go/schemes"
+import "github.com/kpechenenko/max-bot-api-client-go/schemes"
 
 type Message struct {
 	userID  int64

--- a/messages.go
+++ b/messages.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 type messages struct {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 type subscriptions struct {

--- a/uploads.go
+++ b/uploads.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/max-messenger/max-bot-api-client-go/schemes"
+	"github.com/kpechenenko/max-bot-api-client-go/schemes"
 )
 
 type uploads struct {


### PR DESCRIPTION
В документации указано, что тип ИД сообщения - это строка https://dev.max.ru/docs-api/methods/DELETE/messages#Параметры

В реализации методов editMessage и deleteMessage с момента появления репозитория использовался int64. В документации с первой версии api код сообщения всегда был строкой. Соответственно методы не работали. При передаче seqno вместо mdi, который int64, все равно ничего не работало.

После замены типа ИД на строку методы заработали, без ошибок.