### PR TITLE
small fix: rename adimns to admins

### DIFF
--- a/admins/admins.go
+++ b/admins/admins.go
@@ -1,4 +1,4 @@
-package adimns
+package admins
 
 // ChatAdminPermission : Chat admin permissions
 type ChatAdminPermission string


### PR DESCRIPTION
Rename package name ```adimns``` to ```admins```

issue: #50