### PR TITLE
Add URL field to MarkUp struct for link type markup

### DIFF
--- a/schemes/schemes.go
+++ b/schemes/schemes.go
@@ -470,6 +470,7 @@ type MarkUp struct {
 	Length int        `json:"length"`            // length of marker message
 	UserId int64      `json:"user_id,omitempty"` // User identifier, if message was sent to user
 	Type   MarkupType `json:"type"`              // Type of markup
+	URL    string     `json:"url,omitempty"`     // URL for link type markup
 }
 
 type NewMessageLink struct {


### PR DESCRIPTION
## Summary

The API returns a `url` field for markup elements with type `"link"`, but the Go client was not capturing this data. This change adds the missing `URL` field to the `MarkUp` struct to properly parse hyperlinks from messages.

## Changes

- Added `URL string` field with JSON tag `url,omitempty` to `MarkUp` struct in `schemes/schemes.go`

## Related Issue

Fixes #59

---

🤖 Generated with [Claude Code](https://claude.ai/code)