### PR TITLE
Рефакторинг функции  func (b MessageCreatedUpdate) GetCommand() string 

### DIFF
--- a/schemes/schemes.go
+++ b/schemes/schemes.go
@@ -821,13 +821,17 @@ func (b MessageCreatedUpdate) GetText() string {
 }
 
 func (b MessageCreatedUpdate) GetCommand() string {
-	if strings.Index(b.Message.Body.Text, "/") == 0 {
-		if strings.Contains(b.Message.Body.Text, ":") {
-			return strings.Split(b.Message.Body.Text, ":")[0]
-		}
-		return b.Message.Body.Text
+	if !strings.HasPrefix(b.Message.Body.Text, "/") {
+		return "undefened"
 	}
-	return "undefened"
+
+	firstLine := strings.SplitN(b.Message.Body.Text, "\n", 2)[0]
+
+	if strings.Contains(firstLine, ":") {
+		return strings.SplitN(firstLine, ":", 2)[0]
+	}
+
+	return strings.SplitN(firstLine, " ", 2)[0]
 }
 
 func (b MessageCreatedUpdate) GetParam() string {


### PR DESCRIPTION
Проблема: при вызове функции для сообщения без команды возвращается строка "undefened", что, подозреваю, было попыткой вернуть "undefined"

Вопроизведение: вызвать `GetCommand` для события `MessageCreatedUpdate` без команды в сообщение

Ожидаемое поведение: пустая строка в возврате функции

Фактическое поведение: возврат "undefened"

Предлагаю изменить возврат на каноничный для go вид `(string, bool)`, чтобы вызов выглядел так

```go
command, ok := upd.GetCommand()
```

Текущие правки в pull request'е

Упрощена логика `func (b MessageCreatedUpdate) GetCommand() string`

Замнен `strings.Index` на `strings.HasPrefix` воизбежание бесполезного прохода по всему сообщению

Инвертировано условие для уменьшения вложенности.

Учтены пробельные символы в команде

Текущий возврат оставлен во имя обратной совместимости до разрешения вопроса с мейнтейнерами