### PR TITLE
Fix: Add missing 'name' field to User schema

### DIFF
--- a/schemes/schema.yaml
+++ b/schemes/schema.yaml
@@ -1436,6 +1436,11 @@ components:
           description: Users identifier
           type: integer
           format: int64
+          name:
+          description: Visible display name of user or bot
+          type: string
+          nullable: true
+          readOnly: true
         first_name:
           description: Users first name
           type: string


### PR DESCRIPTION
According to real-world API responses (Feb 2026), the User object contains a 'name' field (formatted display name), which was missing in the schema definition.

I discovered that the actual MAX API returns a name field in the User object (sender/recipient), which serves as the display name. This field was missing in the OpenAPI definition.
Proof:

JSON
"sender": {
  "user_id": 12345,
  "first_name": "John",
  "name": "John Doe"  <-- Missing in schema
}
This fix ensures generated clients can access the user's display name directly.

Need help or want to discuss MAX bot architecture? Join our Dev Community: 
Max Chat: https://max.ru/join/xuOCxEvbn0nKepqaooBlHt35UZyvtwWwJoJLdeMzhy4
TG Chat: https://t.me/+l1HWWVASPWY1MmI6