### PR TITLE
Add method AddPhotoByToken in Message struct

### DIFF
--- a/message.go
+++ b/message.go
@@ -88,6 +88,13 @@ func (m *Message) AddPhoto(photo *schemes.PhotoTokens) *Message {
 	return m
 }
 
+func (m *Message) AddPhotoByToken(token string) *Message {
+	m.message.Attachments = append(m.message.Attachments, schemes.NewPhotoAttachmentRequest(schemes.PhotoAttachmentRequestPayload{
+		Token: token,
+	}))
+	return m
+}
+
 func (m *Message) AddAudio(audio *schemes.UploadedInfo) *Message {
 	m.message.Attachments = append(m.message.Attachments, schemes.NewAudioAttachmentRequest(*audio))
 


### PR DESCRIPTION
feat: добавлен метод **AddPhotoByToken** для переиспользования фото при редактировании

Проблема:
При редактировании сообщения (EditMessage) API MAX требует передавать полный payload. Чтобы не загружать старые вложения заново, необходимо передавать их Token.
Сейчас для видео, аудио и файлов это работает отлично, так как их методы (AddVideo, AddAudio, AddFile) принимают структуру UploadedInfo, содержащую поле Token:


```go
info := &schemes.UploadedInfo{Token: attach.Payload.Token}

switch attach.Type {
case schemes.AttachmentVideo:
    maxMesg.AddVideo(info) 
case schemes.AttachmentAudio:
    maxMesg.AddAudio(info) 
// ...
}
```
Однако текущий метод AddPhoto принимает структуру PhotoTokens, которая мапит токены в map[string]PhotoToken (поле Photos) и не позволяет передать единичный корневой Token из старого вложения, так как поля в PhotoAttachmentRequestPayload взаимоисключающие.

Решение:
Добавлен метод AddPhotoByToken(token string), который позволяет напрямую передать токен существующей фотографии. Это делает процесс перезаписи и сохранения старых файлов через токен консистентным и очень легким:

```go
case schemes.AttachmentImage:
    maxMesg.AddPhotoByToken(attach.Payload.Token)
```