### PR TITLE
feat: add webhook check to subscribe

### DIFF
--- a/api.go
+++ b/api.go
@@ -30,10 +30,11 @@ type Api struct {
 	Uploads       *uploads
 	updateHandler UpdateHandler
 
-	client  *client
-	timeout time.Duration
-	pause   time.Duration
-	debug   bool
+	client        *client
+	timeout       time.Duration
+	pause         time.Duration
+	debug         bool
+	webhookSecret string
 }
 
 // New creates a new Max Bot API client with the provided token.
@@ -432,6 +433,11 @@ func (a *Api) GetHandler(updates chan<- schemes.UpdateInterface) http.HandlerFun
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if a.webhookSecret != "" && r.Header.Get("X-Max-Bot-Api-Secret") != a.webhookSecret {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 

--- a/options.go
+++ b/options.go
@@ -59,3 +59,9 @@ func WithUpdateHandler(f UpdateHandler) Option {
 		api.updateHandler = f
 	}
 }
+
+func WithWebhookSecret(secret string) Option {
+	return func(api *Api) {
+		api.webhookSecret = secret
+	}
+}


### PR DESCRIPTION
Решения для issue#115

Добавлена проверка заголовка X-Max-Bot-Api-Secret в обработчике входящих Webhook-запросов. Если при создании клиента указан секрет через WithWebhookSecret, то каждый входящий запрос проверяется на соответствие заголовка при несовпадении возвращается 401 Unauthorized и запрос игнорируется

@wedoca 