### PR TITLE
add stream based uploads for file based wrappers

### DIFF
--- a/uploads.go
+++ b/uploads.go
@@ -35,7 +35,13 @@ func (a *uploads) UploadMediaFromFile(ctx context.Context, uploadType schemes.Up
 	}
 	defer a.client.closer("uploadMediaFromFile file", fh)
 
-	return a.UploadMediaFromReaderWithName(ctx, uploadType, fh, filename)
+	info, err := fh.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+	result := new(schemes.UploadedInfo)
+
+	return result, a.uploadMediaFromReaderWithSize(ctx, uploadType, fh, filename, info.Size(), result)
 }
 
 // UploadMediaFromUrl uploads the file from a remote server to the Max server.
@@ -73,9 +79,14 @@ func (a *uploads) UploadPhotoFromFile(ctx context.Context, fileName string) (*sc
 		return nil, fmt.Errorf("open file: %w", err)
 	}
 	defer a.client.closer("uploadPhotoFromFile file", fh)
+
+	info, err := fh.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
 	result := new(schemes.PhotoTokens)
 
-	return result, a.uploadMediaFromReader(ctx, schemes.PHOTO, fh, fileName, result)
+	return result, a.uploadMediaFromReaderWithSize(ctx, schemes.PHOTO, fh, fileName, info.Size(), result)
 }
 
 // UploadPhotoFromBase64String uploads photos to the Max server.
@@ -145,11 +156,7 @@ func (a *uploads) uploadMediaFromReader(
 	bodyBuf := &bytes.Buffer{}
 	bodyWriter := multipart.NewWriter(bodyBuf)
 
-	if fileName == "" {
-		fileName = "file"
-	} else {
-		fileName = filepath.Base(fileName)
-	}
+	fileName = multipartFileName(fileName)
 
 	fileWriter, err := bodyWriter.CreateFormFile("data", fileName)
 	if err != nil {
@@ -175,6 +182,72 @@ func (a *uploads) uploadMediaFromReader(
 	}
 	defer a.client.closer("uploadMediaFromReader body", resp.Body)
 
+	return a.decodeUploadResponse(resp, uploadType, endpoint.Token, result)
+}
+
+func (a *uploads) uploadMediaFromReaderWithSize(
+	ctx context.Context,
+	uploadType schemes.UploadType,
+	reader io.Reader,
+	fileName string,
+	fileSize int64,
+	result any,
+) error {
+	endpoint, err := a.getUploadURL(ctx, uploadType)
+	if err != nil {
+		return err
+	}
+
+	fileName = multipartFileName(fileName)
+	contentType, contentLength, boundary, err := multipartEnvelope(fileName, fileSize)
+	if err != nil {
+		return fmt.Errorf("prepare multipart: %w", err)
+	}
+
+	bodyReader, bodyWriter := io.Pipe()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.Url, bodyReader)
+	if err != nil {
+		_ = bodyReader.Close()
+		_ = bodyWriter.Close()
+		return fmt.Errorf("create upload request: %w", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = contentLength
+
+	go func() {
+		writer := multipart.NewWriter(bodyWriter)
+		if err := writer.SetBoundary(boundary); err != nil {
+			_ = bodyWriter.CloseWithError(fmt.Errorf("set multipart boundary: %w", err))
+			return
+		}
+
+		fileWriter, err := writer.CreateFormFile("data", fileName)
+		if err != nil {
+			_ = bodyWriter.CloseWithError(fmt.Errorf("create form file: %w", err))
+			return
+		}
+		if _, err = io.Copy(fileWriter, reader); err != nil {
+			_ = bodyWriter.CloseWithError(fmt.Errorf("copy file data: %w", err))
+			return
+		}
+		if err = writer.Close(); err != nil {
+			_ = bodyWriter.CloseWithError(fmt.Errorf("close multipart writer: %w", err))
+			return
+		}
+		_ = bodyWriter.Close()
+	}()
+
+	resp, err := a.client.do(req)
+	if err != nil {
+		return fmt.Errorf("upload: %w", err)
+	}
+	defer a.client.closer("uploadMediaFromReaderWithSize body", resp.Body)
+
+	return a.decodeUploadResponse(resp, uploadType, endpoint.Token, result)
+}
+
+func (a *uploads) decodeUploadResponse(resp *http.Response, uploadType schemes.UploadType, token string, result any) error {
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		apiErr := &schemes.Error{}
 		if decodeErr := jsoniter.NewDecoder(resp.Body).Decode(apiErr); decodeErr == nil {
@@ -189,16 +262,41 @@ func (a *uploads) uploadMediaFromReader(
 
 	if uploadType == schemes.AUDIO || uploadType == schemes.VIDEO {
 		if info, ok := result.(*schemes.UploadedInfo); ok {
-			info.Token = endpoint.Token
+			info.Token = token
 			return nil
 		}
 	}
 
-	if err = jsoniter.NewDecoder(resp.Body).Decode(result); err != nil {
+	if err := jsoniter.NewDecoder(resp.Body).Decode(result); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func multipartEnvelope(fileName string, fileSize int64) (string, int64, string, error) {
+	header := &bytes.Buffer{}
+	writer := multipart.NewWriter(header)
+	boundary := writer.Boundary()
+
+	if _, err := writer.CreateFormFile("data", fileName); err != nil {
+		return "", 0, "", err
+	}
+
+	contentType := writer.FormDataContentType()
+	if err := writer.Close(); err != nil {
+		return "", 0, "", err
+	}
+
+	return contentType, int64(header.Len()) + fileSize, boundary, nil
+}
+
+func multipartFileName(fileName string) string {
+	if fileName == "" {
+		return "file"
+	}
+
+	return filepath.Base(fileName)
 }
 
 func (*uploads) attachmentName(r *http.Response) string {

--- a/uploads_test.go
+++ b/uploads_test.go
@@ -3,9 +3,13 @@ package maxbot
 import (
 	"context"
 	"fmt"
+	"io"
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -68,4 +72,161 @@ func Test_uploads_UploadMediaFromReaderWithName_whenUploadVideoOrAudioType(t *te
 			require.Equal(t, tt.want, result)
 		})
 	}
+}
+
+func Test_uploads_UploadMediaFromFile(t *testing.T) {
+	const fileContent = "file content"
+
+	tempDir := t.TempDir()
+	fileName := filepath.Join(tempDir, "payload.txt")
+	require.NoError(t, os.WriteFile(fileName, []byte(fileContent), 0o600))
+
+	_, contentLength, _, err := multipartEnvelope(filepath.Base(fileName), int64(len(fileContent)))
+	require.NoError(t, err)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/uploads":
+			_, _ = fmt.Fprint(w, `{"url": "`+server.URL+`/mock-upload-file"}`)
+		case "/mock-upload-file":
+			require.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data; boundary="))
+			require.NotEmpty(t, r.Header.Get("Content-Type"))
+			require.Equal(t, contentLength, r.ContentLength)
+
+			part, err := r.MultipartReader()
+			require.NoError(t, err)
+
+			filePart, err := part.NextPart()
+			require.NoError(t, err)
+			require.Equal(t, "data", filePart.FormName())
+			require.Equal(t, filepath.Base(fileName), filePart.FileName())
+
+			body, err := io.ReadAll(filePart)
+			require.NoError(t, err)
+			require.Equal(t, fileContent, string(body))
+
+			_, err = part.NextPart()
+			require.ErrorIs(t, err, io.EOF)
+
+			_, _ = fmt.Fprint(w, `{"file_id": 12345, "token": "new_file_token"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	cl := newClient("bot_token", Version, u, server.Client())
+	upl := newUploads(cl)
+
+	result, err := upl.UploadMediaFromFile(context.Background(), schemes.FILE, fileName)
+	require.NoError(t, err)
+	require.Equal(t, &schemes.UploadedInfo{FileID: 12345, Token: "new_file_token"}, result)
+}
+
+func Test_uploads_UploadPhotoFromFile(t *testing.T) {
+	const fileContent = "photo content"
+
+	tempDir := t.TempDir()
+	fileName := filepath.Join(tempDir, "photo.jpg")
+	require.NoError(t, os.WriteFile(fileName, []byte(fileContent), 0o600))
+
+	_, contentLength, _, err := multipartEnvelope(filepath.Base(fileName), int64(len(fileContent)))
+	require.NoError(t, err)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/uploads":
+			require.Equal(t, string(schemes.PHOTO), r.URL.Query().Get("type"))
+			_, _ = fmt.Fprint(w, `{"url": "`+server.URL+`/mock-upload-photo"}`)
+		case "/mock-upload-photo":
+			require.True(t, strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data; boundary="))
+			require.NotEmpty(t, r.Header.Get("Content-Type"))
+			require.Equal(t, contentLength, r.ContentLength)
+			_, _ = fmt.Fprint(w, `{"photos":{"default":{"token":"photo_token"}}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	cl := newClient("bot_token", Version, u, server.Client())
+	upl := newUploads(cl)
+
+	result, err := upl.UploadPhotoFromFile(context.Background(), fileName)
+	require.NoError(t, err)
+	require.Equal(t, &schemes.PhotoTokens{
+		Photos: map[string]schemes.PhotoToken{
+			"default": {Token: "photo_token"},
+		},
+	}, result)
+}
+
+func Test_uploads_UploadMediaFromFile_matchesBufferedMultipartHeaders(t *testing.T) {
+	const fileContent = "same content"
+
+	tempDir := t.TempDir()
+	fileName := filepath.Join(tempDir, "payload.txt")
+	require.NoError(t, os.WriteFile(fileName, []byte(fileContent), 0o600))
+
+	type uploadRequest struct {
+		header        http.Header
+		contentLength int64
+	}
+
+	requests := make([]uploadRequest, 0, 2)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/uploads":
+			_, _ = fmt.Fprint(w, `{"url": "`+server.URL+`/mock-upload-file"}`)
+		case "/mock-upload-file":
+			requests = append(requests, uploadRequest{
+				header:        r.Header.Clone(),
+				contentLength: r.ContentLength,
+			})
+
+			reader, err := r.MultipartReader()
+			require.NoError(t, err)
+
+			part, err := reader.NextPart()
+			require.NoError(t, err)
+
+			body, err := io.ReadAll(part)
+			require.NoError(t, err)
+			require.Equal(t, fileContent, string(body))
+
+			_, _ = fmt.Fprint(w, `{"file_id": 12345, "token": "new_file_token"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	u, _ := url.Parse(server.URL)
+	cl := newClient("bot_token", Version, u, server.Client())
+	upl := newUploads(cl)
+
+	_, err := upl.UploadMediaFromReaderWithName(context.Background(), schemes.FILE, strings.NewReader(fileContent), fileName)
+	require.NoError(t, err)
+
+	_, err = upl.UploadMediaFromFile(context.Background(), schemes.FILE, fileName)
+	require.NoError(t, err)
+
+	require.Len(t, requests, 2)
+
+	bufferedType, bufferedParams, err := mime.ParseMediaType(requests[0].header.Get("Content-Type"))
+	require.NoError(t, err)
+	streamingType, streamingParams, err := mime.ParseMediaType(requests[1].header.Get("Content-Type"))
+	require.NoError(t, err)
+
+	require.Equal(t, bufferedType, streamingType)
+	require.Equal(t, "multipart/form-data", streamingType)
+	require.NotEmpty(t, bufferedParams["boundary"])
+	require.NotEmpty(t, streamingParams["boundary"])
+	require.Equal(t, requests[0].contentLength, requests[1].contentLength)
 }


### PR DESCRIPTION
Problem: file uploads currently build the entire `multipart/form-data` body in memory, so memory usage grows with file size.

Without introducing a breaking change, only the internal implementation of the existing methods could be changed. Because of that, the optimization was applied to file-based upload methods, where the file size is known in advance.

What was done: `UploadMediaFromFile` and `UploadPhotoFromFile` were switched to streaming multipart uploads via io.Pipe with a precomputed `Content-Length`. The public API and the behavior of reader-based upload methods remain unchanged.

Closes https://github.com/max-messenger/max-bot-api-client-go/issues/123