### PR TITLE
add sugar keyboard

### DIFF
--- a/keyboard.go
+++ b/keyboard.go
@@ -138,3 +138,104 @@ func (k *KeyboardRow) AddClipboard(text, payload string) *KeyboardRow {
 
 	return k
 }
+
+// keyboards sugar
+
+// InlineKeyboard create inline keyboard
+func InlineKeyboard(rows ...[]schemes.ButtonInterface) *Keyboard {
+	k := &Keyboard{
+		rows: make([]*KeyboardRow, 0, len(rows)),
+	}
+	for _, r := range rows {
+		k.rows = append(k.rows, &KeyboardRow{cols: r})
+	}
+	return k
+}
+
+// Row creates one line of buttons.
+func Row(buttons ...schemes.ButtonInterface) []schemes.ButtonInterface {
+	return buttons
+}
+
+// Btn creates a standard Callback button.
+// Optionally, you can pass schemes.Intent (default is schemes.DEFAULT).
+func Btn(text, payload string, intent ...schemes.Intent) schemes.ButtonInterface {
+	i := schemes.DEFAULT
+	if len(intent) > 0 {
+		i = intent[0]
+	}
+	return schemes.CallbackButton{
+		Payload: payload,
+		Intent:  i,
+		Button: schemes.Button{
+			Text: text,
+			Type: schemes.CALLBACK,
+		},
+	}
+}
+
+// BtnLink creates a link button.
+func BtnLink(text, url string) schemes.ButtonInterface {
+	return schemes.LinkButton{
+		Url: url,
+		Button: schemes.Button{
+			Text: text,
+			Type: schemes.LINK,
+		},
+	}
+}
+
+// BtnContact creates a contact request button.
+func BtnContact(text string) schemes.ButtonInterface {
+	return schemes.RequestContactButton{
+		Button: schemes.Button{
+			Text: text,
+			Type: schemes.CONTACT,
+		},
+	}
+}
+
+// BtnGeo creates a location request button.
+func BtnGeo(text string, quick bool) schemes.ButtonInterface {
+	return schemes.RequestGeoLocationButton{
+		Quick: quick,
+		Button: schemes.Button{
+			Text: text,
+			Type: schemes.GEOLOCATION,
+		},
+	}
+}
+
+// BtnApp creates a button to open the Web App.
+func BtnApp(text, app, payload string, contactId int64) schemes.ButtonInterface {
+	return schemes.OpenAppButton{
+		WebApp:    app,
+		Payload:   payload,
+		ContactId: contactId,
+		Button: schemes.Button{
+			Text: text,
+			Type: schemes.OPEN_APP,
+		},
+	}
+}
+
+// BtnMsg creates a button to send text on behalf of the user.
+func BtnMsg(text string) schemes.ButtonInterface {
+	return schemes.MessageButton{
+		Button: schemes.Button{
+			Text: text,
+			Type: schemes.MESSAGE,
+		},
+	}
+}
+
+// BtnClipboard creates a button to copy to the clipboard.
+func BtnClipboard(text, payload string) schemes.ButtonInterface {
+	return schemes.ClipboardButton{
+		Payload: payload,
+		Button: schemes.Button{
+			Text: text,
+			Type: schemes.CLIPBOARD,
+		},
+	}
+}

--- a/keyboard_test.go
+++ b/keyboard_test.go
@@ -1,0 +1,40 @@
+package maxbot
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/max-messenger/max-bot-api-client-go/schemes"
+)
+
+func TestKeyboardSugarEquivalence(t *testing.T) {
+	// Original keyboard
+	builderKb := &Keyboard{}
+
+	row1 := builderKb.AddRow()
+	row1.AddCallback("Yes", schemes.POSITIVE, "agree")
+	row1.AddCallback("Nope", schemes.NEGATIVE, "decline")
+
+	row2 := builderKb.AddRow()
+	row2.AddLink("Site", schemes.DEFAULT, "https://example.com")
+	row2.AddGeolocation("Location", true)
+
+	// Sugar keyboard
+	sugarKb := InlineKeyboard(
+		Row(
+			Btn("Yes", "agree", schemes.POSITIVE),
+			Btn("Nope", "decline", schemes.NEGATIVE),
+		),
+		Row(
+			BtnLink("Site", "https://example.com"),
+			BtnGeo("Location", true),
+		),
+	)
+
+	builderResult := builderKb.Build()
+	sugarResult := sugarKb.Build()
+
+	if !reflect.DeepEqual(builderResult, sugarResult) {
+		t.Errorf("Keyboard structures mismatch!\nBuilder output: %+v\nSugar output:   %+v", builderResult, sugarResult)
+	}
+}


### PR DESCRIPTION
Добавил синтаксический сахар для клавиатуры, позволяющий упростить создание клавиатур.

до
```go
keyboard := api.Messages.NewKeyboardBuilder()
keyboard.
  AddRow().
  AddGeolocation("Прислать геолокацию", true).
  AddContact("Прислать контакт")
keyboard.
  AddRow().
  AddLink("Ссылка", schemes.POSITIVE, "https://max.ru").
  AddCallback("Аудио", schemes.NEGATIVE, "audio").
  AddCallback("Видео", schemes.NEGATIVE, "video")
keyboard.
  AddRow().
  AddCallback("Картинка", schemes.POSITIVE, "picture")
keyboard.
  AddRow().
  AddMessage("Привет!")
keyboard.
  AddRow().
  AddClipboard("Копировать", "https://dev.max.ru/docs-api/methods/POST/messages")
```

после
```go
keyboard := maxbot.InlineKeyboard(
  maxbot.Row(
      maxbot.BtnGeo("Прислать геолокацию", true),
      maxbot.BtnContact("Прислать контакт"),
  ),
  maxbot.Row(
      maxbot.BtnLink("Ссылка", "https://max.ru"),
      maxbot.Btn("Аудио", "audio", schemes.NEGATIVE),
      maxbot.Btn("Видео", "video", schemes.NEGATIVE),
  ),
  maxbot.Row(
      maxbot.Btn("Картинка", "picture", schemes.POSITIVE),
  ),
  maxbot.Row(
      maxbot.BtnMsg("Привет!"),
  ),
  maxbot.Row(
      maxbot.BtnClipboard("Копировать", "https://dev.max.ru/docs-api/methods/POST/messages"),
  ),
)
```