### PR TITLE
fix: увеличить и сделать настраиваемым буфер канала ошибок

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,7 +38,7 @@ func newClient(key string, version string, baseURL *url.URL, httpClient HttpClie
 		version:    version,
 		baseURL:    baseURL,
 		httpClient: httpClient,
-		errors:     make(chan error, 1),
+		errors:     make(chan error, defaultErrorBufferSize),
 	}
 }
 

--- a/const.go
+++ b/const.go
@@ -12,6 +12,11 @@ const (
 	defaultPause    = 1 * time.Second
 	maxUpdatesLimit = 50
 
+	// defaultErrorBufferSize — ёмкость канала ошибок по умолчанию. Буфер в 1
+	// элемент терял ошибки при всплесках (например, при повторных сбоях long
+	// polling): лишние ошибки уходили только в log, минуя GetErrors().
+	defaultErrorBufferSize = 16
+
 	maxRetries = 3
 )
 
@@ -58,4 +63,3 @@ const (
 	paramLimit   = "limit"
 	paramTimeout = "timeout"
 )
-

--- a/options.go
+++ b/options.go
@@ -59,3 +59,15 @@ func WithUpdateHandler(f UpdateHandler) Option {
 		api.updateHandler = f
 	}
 }
+
+// WithErrorBufferSize задаёт ёмкость канала ошибок, возвращаемого GetErrors().
+// Больший буфер снижает риск потери ошибок при всплесках (повторные сбои long
+// polling и т.п.). Значения меньше 1 игнорируются.
+func WithErrorBufferSize(size int) Option {
+	return func(api *Api) {
+		if size < 1 {
+			return
+		}
+		api.client.errors = make(chan error, size)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,56 @@
+package maxbot
+
+import "testing"
+
+func TestDefaultErrorBufferSize(t *testing.T) {
+	api, err := New("token")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	if got := cap(api.client.errors); got != defaultErrorBufferSize {
+		t.Fatalf("expected default error buffer %d, got %d", defaultErrorBufferSize, got)
+	}
+}
+
+func TestWithErrorBufferSize(t *testing.T) {
+	api, err := New("token", WithErrorBufferSize(64))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	if got := cap(api.client.errors); got != 64 {
+		t.Fatalf("expected error buffer 64, got %d", got)
+	}
+}
+
+func TestWithErrorBufferSizeIgnoresNonPositive(t *testing.T) {
+	api, err := New("token", WithErrorBufferSize(0))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	if got := cap(api.client.errors); got != defaultErrorBufferSize {
+		t.Fatalf("non-positive size must keep default %d, got %d", defaultErrorBufferSize, got)
+	}
+}
+
+func TestNotifyErrorKeepsBurstWithinBuffer(t *testing.T) {
+	api, err := New("token", WithErrorBufferSize(4))
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	cl := api.client
+	for i := 0; i < 4; i++ {
+		cl.notifyError(errForTest(i))
+	}
+	// All four must be retained by the channel, not dropped to the log.
+	for i := 0; i < 4; i++ {
+		select {
+		case <-api.GetErrors():
+		default:
+			t.Fatalf("expected %d buffered errors, channel drained early at %d", 4, i)
+		}
+	}
+}
+
+type errForTest int
+
+func (e errForTest) Error() string { return "test error" }


### PR DESCRIPTION
Канал ошибок создаётся с буфером 1, а `notifyError` пишет в него неблокирующе - при заполнении ошибка уходит только в `log.Println`, минуя `GetErrors()`. При всплеске ошибок (например, повторные сбои long polling) потребитель `GetErrors()` видит лишь одну из них, остальные теряются.

## Изменения
- буфер канала ошибок по умолчанию увеличен с 1 до 16 (`defaultErrorBufferSize`);
- добавлена опция `WithErrorBufferSize(size int)` для настройки ёмкости;
- неблокирующая семантика `notifyError` сохранена - нет риска дедлока, если `GetErrors()` не читают.

## Тесты
Добавлен `options_test.go`: дефолтная ёмкость, установка через опцию, игнор значений < 1, отсутствие потерь при всплеске в пределах буфера. `go test ./...` - зелёный.