### PR TITLE
fix: не свапать from/to в GetMessages (#136)

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -39,10 +39,13 @@ func (a *messages) GetMessages(ctx context.Context, chatID int64, messageIDs []s
 	if len(messageIDs) > 0 {
 		values.Set(paramMessageIDs, strings.Join(messageIDs, ","))
 	}
-	// If you use 'from' and 'to' parameters, 'to' must be less than 'from'.
-	if from > to {
-		to, from = from, to
-	}
+	// По контракту API 'from' - верхняя граница времени
+	// (все сообщения с начала чата до 'from', t <= from),
+	// 'to' - нижняя (все сообщения начиная с 'to' до конца чата,
+	// t >= to), поэтому 'to' должно быть меньше 'from'. Раньше здесь был свап
+	// from/to, который инвертировал корректно заданный диапазон и приводил к
+	// пустому результату или возврату последних count сообщений.
+	// https://dev.max.ru/docs-api/methods/GET/messages
 	if from != 0 {
 		values.Set(paramFrom, strconv.Itoa(from))
 	}

--- a/messages_test.go
+++ b/messages_test.go
@@ -1,0 +1,54 @@
+package maxbot
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetMessagesPassesFromToAsIs проверяет, что GetMessages передаёт параметры
+// from/to ровно как заданы вызывающим кодом, без свапа (issue #136). По
+// контракту API from — верхняя граница (t <= from), to — нижняя (t >= to),
+// поэтому корректный диапазон имеет from > to и не должен инвертироваться.
+func TestGetMessagesPassesFromToAsIs(t *testing.T) {
+	var gotFrom, gotTo string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotFrom = r.URL.Query().Get("from")
+		gotTo = r.URL.Query().Get("to")
+		_, _ = w.Write([]byte(`{"messages":[]}`))
+	}))
+	defer server.Close()
+
+	api, err := New("token", WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	_, err = api.Messages.GetMessages(context.Background(), 1, nil, 2000, 1000, 50)
+	require.NoError(t, err)
+
+	require.Equal(t, "2000", gotFrom, "from must be passed unchanged")
+	require.Equal(t, "1000", gotTo, "to must be passed unchanged")
+}
+
+// TestGetMessagesOmitsZeroBounds проверяет, что нулевые from/to не отправляются
+// (открытая граница диапазона).
+func TestGetMessagesOmitsZeroBounds(t *testing.T) {
+	var hasFrom, hasTo bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hasFrom = r.URL.Query()["from"]
+		_, hasTo = r.URL.Query()["to"]
+		_, _ = w.Write([]byte(`{"messages":[]}`))
+	}))
+	defer server.Close()
+
+	api, err := New("token", WithBaseURL(server.URL))
+	require.NoError(t, err)
+
+	_, err = api.Messages.GetMessages(context.Background(), 1, nil, 0, 1000, 50)
+	require.NoError(t, err)
+
+	require.False(t, hasFrom, "from=0 must be omitted")
+	require.True(t, hasTo, "to must be present")
+}


### PR DESCRIPTION
Closes #136

GetMessages при `from > to` менял параметры местами, инвертируя корректно заданный диапазон. По контракту API `from` - верхняя граница времени (`t <= from`), `to` - нижняя (`t >= to`), поэтому корректный диапазон имеет `from > to`. Из-за свапа API получал перевёрнутый интервал и возвращал пустой результат либо последние `count` сообщений.

## Изменения
- удалён свап `from/to`;
- Добавлен комментарий;
- добавлены тесты (`messages_test.go`): параметры передаются как заданы, нулевые границы опускаются.

## Проверка
`go test ./...` - зелёный.

## Дока
https://dev.max.ru/docs-api/methods/GET/messages